### PR TITLE
Simplify and ES6-ify

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -22,7 +22,8 @@
       ],
       "js": [
         "src/inject.js"
-      ]
+      ],
+      "run_at": "document_end"
     }
   ]
 }

--- a/src/inject.js
+++ b/src/inject.js
@@ -30,7 +30,7 @@ function formatKiloBytes (bytes) {
 }
 
 function checkStatus (response) {
-  if (200 <= response.status < 300) {
+  if (response.status >= 200 && response.status < 300) {
     return response
   }
 

--- a/src/inject.js
+++ b/src/inject.js
@@ -1,4 +1,4 @@
-/* global chrome, fetch*/
+/* global fetch */
 
 const API = 'https://api.github.com/repos/'
 

--- a/src/inject.js
+++ b/src/inject.js
@@ -19,9 +19,9 @@ function formatKiloBytes (bytes) {
 
   bytes *= 1024
 
-  const K = 1024,
-    MEASURE = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'],
-    i = Math.floor(Math.log(bytes) / Math.log(K))
+  const K = 1024
+  const MEASURE = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
+  const i = Math.floor(Math.log(bytes) / Math.log(K))
 
   return {
     size: parseFloat((bytes / Math.pow(K, i)).toFixed(2)),

--- a/src/inject.js
+++ b/src/inject.js
@@ -32,25 +32,25 @@ function formatKiloBytes (bytes) {
 function checkStatus (response) {
   if (200 <= response.status < 300) {
     return response
-  } else {
-    return null
   }
+
+  throw Error(`GitHub returned a bad status: ${response.status}`)
 }
 
 function parseJSON (response) {
-  return response === null ? null : response.json()
+  if (response) {
+    return response.json()
+  }
+
+  throw Error('Could not parse JSON')
 }
 
 function getRepoSize (repo, callback) {
   fetch(API + repo)
     .then(checkStatus)
     .then(parseJSON)
-    .then(function (data) {
-      callback(data === null ? null : data.size)
-    }).catch(function (error) {
-      if (error) {}
-      callback(null)
-    })
+    .then(data => callback(data && data.size))
+    .catch(e => console.error(e))
 }
 
 chrome.extension.sendMessage({}, function (response) {

--- a/src/inject.js
+++ b/src/inject.js
@@ -53,32 +53,24 @@ function getRepoSize (repo, callback) {
     .catch(e => console.error(e))
 }
 
-chrome.extension.sendMessage({}, function (response) {
-  var readyStateCheckInterval = setInterval(function () {
-    if (document.readyState === 'complete') {
-      clearInterval(readyStateCheckInterval)
+var ns = document.querySelector('ul.numbers-summary')
 
-      var ns = document.querySelector('ul.numbers-summary')
-
-      if (ns !== null) {
-        getRepoSize(getUsernameWithReponameFromGithubURL(window.location.href), function (size) {
-          if (size !== null) {
-            var humanReadableSize = formatKiloBytes(size)
-            var html = '<li>' +
-              '<a>' +
-              '<svg class="octicon octicon-database" aria-hidden="true" height="16" version="1.1" viewBox="0 0 12 16" width="12">' +
-              '<path d="M6 15c-3.31 0-6-.9-6-2v-2c0-.17.09-.34.21-.5.67.86 3 1.5 5.79 1.5s5.12-.64 5.79-1.5c.13.16.21.33.21.5v2c0 1.1-2.69 2-6 2zm0-4c-3.31 0-6-.9-6-2V7c0-.11.04-.21.09-.31.03-.06.07-.13.12-.19C.88 7.36 3.21 8 6 8s5.12-.64 5.79-1.5c.05.06.09.13.12.19.05.1.09.21.09.31v2c0 1.1-2.69 2-6 2zm0-4c-3.31 0-6-.9-6-2V3c0-1.1 2.69-2 6-2s6 .9 6 2v2c0 1.1-2.69 2-6 2zm0-5c-2.21 0-4 .45-4 1s1.79 1 4 1 4-.45 4-1-1.79-1-4-1z"></path>' +
-              '</svg>' +
-              '<span class="num text-emphasized"> ' +
-              humanReadableSize.size +
-              '</span> ' +
-              humanReadableSize.measure +
-              '</a>' +
-              '</li>'
-            ns.insertAdjacentHTML('beforeend', html)
-          }
-        })
-      }
+if (ns !== null) {
+  getRepoSize(getUsernameWithReponameFromGithubURL(window.location.href), function (size) {
+    if (size) {
+      const humanReadableSize = formatKiloBytes(size)
+      const html = '<li>' +
+        '<a>' +
+        '<svg class="octicon octicon-database" aria-hidden="true" height="16" version="1.1" viewBox="0 0 12 16" width="12">' +
+        '<path d="M6 15c-3.31 0-6-.9-6-2v-2c0-.17.09-.34.21-.5.67.86 3 1.5 5.79 1.5s5.12-.64 5.79-1.5c.13.16.21.33.21.5v2c0 1.1-2.69 2-6 2zm0-4c-3.31 0-6-.9-6-2V7c0-.11.04-.21.09-.31.03-.06.07-.13.12-.19C.88 7.36 3.21 8 6 8s5.12-.64 5.79-1.5c.05.06.09.13.12.19.05.1.09.21.09.31v2c0 1.1-2.69 2-6 2zm0-4c-3.31 0-6-.9-6-2V3c0-1.1 2.69-2 6-2s6 .9 6 2v2c0 1.1-2.69 2-6 2zm0-5c-2.21 0-4 .45-4 1s1.79 1 4 1 4-.45 4-1-1.79-1-4-1z"></path>' +
+        '</svg>' +
+        '<span class="num text-emphasized"> ' +
+        humanReadableSize.size +
+        '</span> ' +
+        humanReadableSize.measure +
+        '</a>' +
+        '</li>'
+      ns.insertAdjacentHTML('beforeend', html)
     }
-  }, 10)
-})
+  })
+}

--- a/src/inject.js
+++ b/src/inject.js
@@ -30,7 +30,7 @@ function formatKiloBytes (bytes) {
 }
 
 function checkStatus (response) {
-  if (response.status >= 200 && response.status < 300) {
+  if (200 <= response.status < 300) {
     return response
   } else {
     return null

--- a/src/inject.js
+++ b/src/inject.js
@@ -1,6 +1,6 @@
 /* global chrome, fetch*/
 
-var API = 'https://api.github.com/repos/'
+const API = 'https://api.github.com/repos/'
 
 function getUsernameWithReponameFromGithubURL (url) {
   var parser = document.createElement('a')
@@ -19,9 +19,9 @@ function formatKiloBytes (bytes) {
 
   bytes *= 1024
 
-  var K = 1024
-  var MEASURE = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
-  var i = Math.floor(Math.log(bytes) / Math.log(K))
+  const K = 1024,
+    MEASURE = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'],
+    i = Math.floor(Math.log(bytes) / Math.log(K))
 
   return {
     size: parseFloat((bytes / Math.pow(K, i)).toFixed(2)),


### PR DESCRIPTION
This PR includes a handful of small tweaks and optimizations, leveraging ES6 wherever possible.

The two largest changes are:
- Instead of passing around `null` to our different functions, we can just throw the error on the spot, `catch` the error, and then log the error. Let me know what you think about logging the error vs. not logging the error. I don't have a strong opinion either way.
- Removing the `setInterval` code. Chrome is very helpful in that it will inject the extension's code right when the DOM is loaded, so we shouldn't need to listen to `document.readyState` ourselves.