### PR TITLE
Changes to enable use in Firefox too

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -13,6 +13,7 @@
   "permissions": [
     "http://github.com/*",
     "https://github.com/*",
+    "https://api.github.com/*",
     "storage",
     "activeTab"
   ],

--- a/src/background.js
+++ b/src/background.js
@@ -3,11 +3,13 @@
 const GITHUB_TOKEN_KEY = 'x-github-token'
 const TOKEN_FEATURE_INFORMATION_KEY = 'user-knows-token-feature'
 
+const storage = chrome.storage.sync || chrome.storage.local
+
 function setGithubToken (key, cb) {
   const obj = {}
   obj[GITHUB_TOKEN_KEY] = key
 
-  chrome.storage.local.set(obj, function () {
+  storage.set(obj, function () {
     alert('Your Github token has been set successfully. Reload the Github page to see changes.')
 
     cb()
@@ -15,12 +17,12 @@ function setGithubToken (key, cb) {
 }
 
 function handleOldGithubToken (cb) {
-  chrome.storage.local.get(GITHUB_TOKEN_KEY, function (storedData) {
+  storage.get(GITHUB_TOKEN_KEY, function (storedData) {
     const oldGithubToken = storedData[GITHUB_TOKEN_KEY]
 
     if (oldGithubToken) {
       if (confirm('You have already set your Github token. Do you want to remove it?')) {
-        chrome.storage.local.remove(GITHUB_TOKEN_KEY, function () {
+        storage.remove(GITHUB_TOKEN_KEY, function () {
           alert('You have successfully removed Github token. Click extension icon again to set a new token.')
 
           cb(false)
@@ -38,11 +40,11 @@ function userNowKnowsAboutGithubTokenFeature (cb) {
   const obj = {}
   obj[TOKEN_FEATURE_INFORMATION_KEY] = true
 
-  chrome.storage.local.set(obj, cb)
+  storage.set(obj, cb)
 }
 
 function informUserAboutGithubTokenFeature () {
-  chrome.storage.local.get(TOKEN_FEATURE_INFORMATION_KEY, function (storedData) {
+  storage.get(TOKEN_FEATURE_INFORMATION_KEY, function (storedData) {
     const userKnows = storedData[TOKEN_FEATURE_INFORMATION_KEY]
 
     if (!userKnows) {

--- a/src/background.js
+++ b/src/background.js
@@ -7,7 +7,7 @@ function setGithubToken (key, cb) {
   const obj = {}
   obj[GITHUB_TOKEN_KEY] = key
 
-  chrome.storage.sync.set(obj, function () {
+  chrome.storage.local.set(obj, function () {
     alert('Your Github token has been set successfully. Reload the Github page to see changes.')
 
     cb()
@@ -15,12 +15,12 @@ function setGithubToken (key, cb) {
 }
 
 function handleOldGithubToken (cb) {
-  chrome.storage.sync.get(GITHUB_TOKEN_KEY, function (storedData) {
+  chrome.storage.local.get(GITHUB_TOKEN_KEY, function (storedData) {
     const oldGithubToken = storedData[GITHUB_TOKEN_KEY]
 
     if (oldGithubToken) {
       if (confirm('You have already set your Github token. Do you want to remove it?')) {
-        chrome.storage.sync.remove(GITHUB_TOKEN_KEY, function () {
+        chrome.storage.local.remove(GITHUB_TOKEN_KEY, function () {
           alert('You have successfully removed Github token. Click extension icon again to set a new token.')
 
           cb(false)
@@ -38,11 +38,11 @@ function userNowKnowsAboutGithubTokenFeature (cb) {
   const obj = {}
   obj[TOKEN_FEATURE_INFORMATION_KEY] = true
 
-  chrome.storage.sync.set(obj, cb)
+  chrome.storage.local.set(obj, cb)
 }
 
 function informUserAboutGithubTokenFeature () {
-  chrome.storage.sync.get(TOKEN_FEATURE_INFORMATION_KEY, function (storedData) {
+  chrome.storage.local.get(TOKEN_FEATURE_INFORMATION_KEY, function (storedData) {
     const userKnows = storedData[TOKEN_FEATURE_INFORMATION_KEY]
 
     if (!userKnows) {

--- a/src/inject.js
+++ b/src/inject.js
@@ -158,7 +158,7 @@ function checkForRepoPage () {
   }
 }
 
-chrome.storage.sync.get(GITHUB_TOKEN_KEY, function (data) {
+chrome.storage.local.get(GITHUB_TOKEN_KEY, function (data) {
   githubToken = data[GITHUB_TOKEN_KEY]
 
   chrome.storage.onChanged.addListener(function (changes, namespace) {

--- a/src/inject.js
+++ b/src/inject.js
@@ -4,6 +4,8 @@ const API = 'https://api.github.com/repos/'
 const LI_TAG_ID = 'github-repo-size'
 const GITHUB_TOKEN_KEY = 'x-github-token'
 
+const storage = chrome.storage.sync || chrome.storage.local
+
 let githubToken
 
 function isTree (uri) {
@@ -158,7 +160,7 @@ function checkForRepoPage () {
   }
 }
 
-chrome.storage.local.get(GITHUB_TOKEN_KEY, function (data) {
+storage.get(GITHUB_TOKEN_KEY, function (data) {
   githubToken = data[GITHUB_TOKEN_KEY]
 
   chrome.storage.onChanged.addListener(function (changes, namespace) {


### PR DESCRIPTION
The `chrome.storage.sync` API is not yet supported in Firefox stable but it's apparently already implemented and will be available in Firefox 53. Because of this I added a fallback to `chrome.storage.local`.

I also had to add a host permission to the GitHub API endpoint, which is needed for the AJAX requests as documented [here](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/manifest.json/permissions#Host_permissions).