### PR TITLE
Drop unnecessary tag

### DIFF
--- a/src/inject.js
+++ b/src/inject.js
@@ -59,7 +59,6 @@ const getSizeHTML = (size) => {
   const humanReadableSize = getHumanReadableSizeObject(size)
 
   return '<li id="' + LI_TAG_ID + '">' +
-    '<a>' +
     '<svg class="octicon octicon-database" aria-hidden="true" height="16" version="1.1" viewBox="0 0 12 16" width="12">' +
     '<path d="M6 15c-3.31 0-6-.9-6-2v-2c0-.17.09-.34.21-.5.67.86 3 1.5 5.79 1.5s5.12-.64 5.79-1.5c.13.16.21.33.21.5v2c0 1.1-2.69 2-6 2zm0-4c-3.31 0-6-.9-6-2V7c0-.11.04-.21.09-.31.03-.06.07-.13.12-.19C.88 7.36 3.21 8 6 8s5.12-.64 5.79-1.5c.05.06.09.13.12.19.05.1.09.21.09.31v2c0 1.1-2.69 2-6 2zm0-4c-3.31 0-6-.9-6-2V3c0-1.1 2.69-2 6-2s6 .9 6 2v2c0 1.1-2.69 2-6 2zm0-5c-2.21 0-4 .45-4 1s1.79 1 4 1 4-.45 4-1-1.79-1-4-1z"></path>' +
     '</svg>' +
@@ -67,7 +66,6 @@ const getSizeHTML = (size) => {
     humanReadableSize.size +
     '</span> ' +
     humanReadableSize.measure +
-    '</a>' +
     '</li>'
 }
 


### PR DESCRIPTION
The empty `<a>` was enabling a hover style on the size:

![hover demo](https://user-images.githubusercontent.com/1402241/28148294-5c79bbce-67b8-11e7-8d68-33c157273bd5.gif)
