### PR TITLE
Add folder size display, via git/trees API. Fixes #19.

### DIFF
--- a/src/inject.js
+++ b/src/inject.js
@@ -150,7 +150,6 @@ const checkForRepoPage = () => {
           if (item.path.startsWith(repoPath)) {
             const commonPathPrefix = item.path.replace(new RegExp('^' + repoPath + '/?'), '').split('/')[0]
             sizeArray[commonPathPrefix] = (sizeArray[commonPathPrefix] || 0) + (item.size || 0)
-            // console.log('getRepoTreeURI saved item: ' + commonPathPrefix + ' as ' + sizeArray[commonPathPrefix])
           }
         }
 

--- a/src/inject.js
+++ b/src/inject.js
@@ -29,6 +29,20 @@ const getRepoContentURI = (uri) => {
   return repoURI.join('/')
 }
 
+const getRepoTreeURI = (uri) => {
+    const repoURI = uri.split('/')
+    const treeBranch = repoURI.splice(2)
+
+    repoURI.push('git/trees')
+    if (treeBranch && treeBranch[1]) {
+        repoURI.push(treeBranch[1])
+    } else {
+        repoURI.push('master')
+    }
+
+    return repoURI.join('/') + '?recursive=1'
+}
+
 const getHumanReadableSizeObject = (bytes) => {
   if (bytes === 0) {
     return {
@@ -113,6 +127,7 @@ const getFileName = (text) => text.trim().split('/')[0]
 
 const checkForRepoPage = () => {
   const repoURI = window.location.pathname.substring(1)
+  const repoPath = repoURI.split('/').splice(4).join('/').trim()
 
   if (isTree(repoURI)) {
     const ns = document.querySelector('ul.numbers-summary')
@@ -128,11 +143,15 @@ const checkForRepoPage = () => {
     }
 
     if (!tdElems) {
-      getAPIData(getRepoContentURI(repoURI), (data) => {
+      getAPIData(getRepoTreeURI(repoURI), (data) => {
         const sizeArray = {}
 
-        for (const item of data) {
-          sizeArray[item.name] = item.type !== 'dir' ? item.size : null
+        for (const item of data.tree) {
+          if (item.path.startsWith(repoPath)) {
+            const commonPathPrefix = item.path.replace(new RegExp('^' + repoPath + '/?'), '').split('/')[0]
+            sizeArray[commonPathPrefix] = (sizeArray[commonPathPrefix] || 0) + (item.size || 0)
+            // console.log('getRepoTreeURI saved item: ' + commonPathPrefix + ' as ' + sizeArray[commonPathPrefix])
+          }
         }
 
         const list = document.querySelectorAll('table > tbody tr.js-navigation-item:not(.up-tree)')


### PR DESCRIPTION
Hi @harshjv, in the spirit of [Hacktoberfest](https://hacktoberfest.digitalocean.com), I wanted to offer help contributing to `github-repo-size`, which I use every day and find extremely useful!

I decided to look at issue #19, to show sizes of folders. I found that by switching to the [GitHub Trees API in recursive mode](https://developer.github.com/v3/git/trees/#get-a-tree-recursively), the size of folders could be determined by summing up the size of their files.

Here's an example of what it like:
<img width="990" alt="show-folder-sizes" src="https://user-images.githubusercontent.com/6874678/32131307-a5e516b2-bb70-11e7-9650-a5858153f7d7.png">

Let me know what you think, and thanks again for this great Chrome extension!