### PR TITLE
Support repository URL with trailing slash

### DIFF
--- a/src/inject.js
+++ b/src/inject.js
@@ -112,7 +112,8 @@ const getAPIData = (uri, callback) => {
 const getFileName = (text) => text.trim().split('/')[0]
 
 const checkForRepoPage = () => {
-  const repoURI = window.location.pathname.substring(1)
+  let repoURI = window.location.pathname.substring(1)
+  repoURI = repoURI.endsWith('/') ? repoURI.slice(0, -1) : repoURI
 
   if (isTree(repoURI)) {
     const ns = document.querySelector('ul.numbers-summary')


### PR DESCRIPTION
For example, if you navigate to [https://github.com/harshjv/github-repo-size/](https://github.com/harshjv/github-repo-size/) — size will not be displayed.