### PR TITLE
Wrap the size text in a span tag, fix a typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To enable viewing size of private repositories;
 3. Click on the Github Repo Size extension (this extension)'s icon aside the address bar.
 4. Paste your access token there in the prompt box.
 
-### Temporarily override then token
+### Temporarily override the token
 
 You can set `x-github-token` in `localStorage` to your access token, and the extension will use this value even if you've previously set token.
 

--- a/src/inject.js
+++ b/src/inject.js
@@ -61,6 +61,7 @@ const getSizeHTML = (size) => {
   const humanReadableSize = getHumanReadableSizeObject(size)
 
   return '<li id="' + LI_TAG_ID + '">' +
+    '<span class="nolink">' +
     '<svg class="octicon octicon-database" aria-hidden="true" height="16" version="1.1" viewBox="0 0 12 16" width="12">' +
     '<path d="M6 15c-3.31 0-6-.9-6-2v-2c0-.17.09-.34.21-.5.67.86 3 1.5 5.79 1.5s5.12-.64 5.79-1.5c.13.16.21.33.21.5v2c0 1.1-2.69 2-6 2zm0-4c-3.31 0-6-.9-6-2V7c0-.11.04-.21.09-.31.03-.06.07-.13.12-.19C.88 7.36 3.21 8 6 8s5.12-.64 5.79-1.5c.05.06.09.13.12.19.05.1.09.21.09.31v2c0 1.1-2.69 2-6 2zm0-4c-3.31 0-6-.9-6-2V3c0-1.1 2.69-2 6-2s6 .9 6 2v2c0 1.1-2.69 2-6 2zm0-5c-2.21 0-4 .45-4 1s1.79 1 4 1 4-.45 4-1-1.79-1-4-1z"></path>' +
     '</svg>' +
@@ -68,6 +69,7 @@ const getSizeHTML = (size) => {
     humanReadableSize.size +
     '</span> ' +
     humanReadableSize.measure +
+    '</span>' +
     '</li>'
 }
 


### PR DESCRIPTION
The span tag with a 'nolink' class will make it look like the others :)