### PR TITLE
Add folder size display on demand, via git/trees API. Fixes #19.

### DIFF
--- a/src/inject.js
+++ b/src/inject.js
@@ -150,7 +150,6 @@ const checkForRepoPage = () => {
           if (item.path.startsWith(repoPath)) {
             const commonPathPrefix = item.path.replace(new RegExp('^' + repoPath + '/?'), '').split('/')[0]
             sizeArray[commonPathPrefix] = (sizeArray[commonPathPrefix] || 0) + (item.size || 0)
-            // console.log('getRepoTreeURI saved item: ' + commonPathPrefix + ' as ' + sizeArray[commonPathPrefix])
           }
         }
 

--- a/src/inject.js
+++ b/src/inject.js
@@ -193,7 +193,7 @@ const checkForRepoPage = () => {
 
 const loadFolderSizes = () => {
   const files = document.querySelectorAll('table > tbody tr.js-navigation-item:not(.up-tree) td.content a')
-  const folderSizes = document.querySelectorAll("td.github-repo-size-folder > span")
+  const folderSizes = document.querySelectorAll('td.github-repo-size-folder > span')
 
   const liElem = document.getElementById(LI_TAG_ID)
   if (liElem) {
@@ -210,6 +210,9 @@ const loadFolderSizes = () => {
   const repoPath = getRepoPath()
 
   getAPIData(getRepoTreeURI(repoURI), (data) => {
+    if (data.truncated) {
+      console.warn('github-repo-size: Data truncated. Folder size info may be incomplete.')
+    }
     const sizeArray = {}
     for (const item of data.tree) {
       if (item.path.startsWith(repoPath)) {

--- a/src/inject.js
+++ b/src/inject.js
@@ -29,6 +29,20 @@ const getRepoContentURI = (uri) => {
   return repoURI.join('/')
 }
 
+const getRepoTreeURI = (uri) => {
+    const repoURI = uri.split('/')
+    const treeBranch = repoURI.splice(2)
+
+    repoURI.push('git/trees')
+    if (treeBranch && treeBranch[1]) {
+        repoURI.push(treeBranch[1])
+    } else {
+        repoURI.push('master')
+    }
+
+    return repoURI.join('/') + '?recursive=1'
+}
+
 const getHumanReadableSizeObject = (bytes) => {
   if (bytes === 0) {
     return {
@@ -113,6 +127,7 @@ const getFileName = (text) => text.trim().split('/')[0]
 
 const checkForRepoPage = () => {
   const repoURI = window.location.pathname.substring(1)
+  const repoPath = repoURI.split('/').splice(4).join('/').trim()
 
   if (isTree(repoURI)) {
     const ns = document.querySelector('ul.numbers-summary')
@@ -128,11 +143,15 @@ const checkForRepoPage = () => {
     }
 
     if (!tdElems) {
-      getAPIData(getRepoContentURI(repoURI), (data) => {
+      getAPIData(getRepoTreeURI(repoURI), (data) => {
         const sizeArray = {}
 
-        for (const item of data) {
-          sizeArray[item.name] = item.type !== 'dir' ? item.size : null
+        for (const item of data.tree) {
+          if (item.path.startsWith(repoPath)) {
+            const commonPathPrefix = item.path.replace(new RegExp('^' + repoPath + '/?'), '').split('/')[0]
+            sizeArray[commonPathPrefix] = (sizeArray[commonPathPrefix] || 0) + (item.size || 0)
+            // console.log('getRepoTreeURI saved item: ' + commonPathPrefix + ' as ' + sizeArray[commonPathPrefix])
+          }
         }
 
         const list = document.querySelectorAll('table > tbody tr.js-navigation-item:not(.up-tree)')


### PR DESCRIPTION
Hi @harshjv, as I mentioned in #26, I wanted to revise this feature addition based on your feedback. I changed the implementation, so that now instead of fetching the full repo tree right away, it shows `---` for the size of folders, and if you click on that (or on the top repo size indicator), it will then fetch that folder size info and display it. It seems to work well for small repos and big ones too.

I have tested this and the code works well, although in its current form it is not super discoverable. I added `title` attributes to the clickable elements, but I was also considering using some sort of icon or link saying "Load Folder Sizes." I was curious what you thought about this before adding it though.

Let me know what you think, and thanks again for this useful extension!