### PR TITLE
Fix bug: table update error while using file view

### DIFF
--- a/src/inject.js
+++ b/src/inject.js
@@ -132,20 +132,24 @@ const checkForRepoPage = async () => {
   const ns = document.querySelector('ul.UnderlineNav-body')
   const navElem = document.getElementById(NAV_ELEM_ID)
   const tdElems = document.querySelector('span.github-repo-size-div')
+  
+  // whether 'add file' button is present
+  const viewingDir = document.querySelector('div.file-navigation.mb-3.d-flex.flex-items-start > div.d-flex > details > summary > span.btn.d-none.d-md-flex.flex-items-center') && true
 
   if (ns && !navElem) {
     getAPIData(repoObj.repo).then(summary => {
       if (summary && summary.size) {
         ns.insertAdjacentHTML('beforeend', getSizeHTML(summary.size * 1024))
         const newLiElem = document.getElementById(NAV_ELEM_ID)
-        newLiElem.title = 'Click to load directory sizes'
-        newLiElem.style.cssText = 'cursor: pointer'
-        newLiElem.onclick = loadDirSizes
+        if(viewingDir) {
+          newLiElem.title = 'Click to load directory sizes'
+          newLiElem.onclick = loadDirSizes
+        }
       }
     })
   }
 
-  if (tdElems) return
+  if (!viewingDir || tdElems) return
 
   const tree = await getAPIData(`${repoObj.repo}/contents/${repoObj.currentPath}?ref=${repoObj.ref}`)
   const sizeObj = { '..': '..' }

--- a/src/inject.js
+++ b/src/inject.js
@@ -132,20 +132,24 @@ const checkForRepoPage = async () => {
   const ns = document.querySelector('ul.UnderlineNav-body')
   const navElem = document.getElementById(NAV_ELEM_ID)
   const tdElems = document.querySelector('span.github-repo-size-div')
+  
+  // whether 'add file' button is present
+  const viewingDir = document.querySelector('div.file-navigation.mb-3.d-flex.flex-items-start > details.details-overlay.details-reset.position-relative > summary > span.btn.d-none.d-md-flex.flex-items-center') || document.querySelector('div.file-navigation.mb-3.d-flex.flex-items-start > div.d-flex > details > summary > span.btn.d-none.d-md-flex.flex-items-center')
 
   if (ns && !navElem) {
     getAPIData(repoObj.repo).then(summary => {
       if (summary && summary.size) {
         ns.insertAdjacentHTML('beforeend', getSizeHTML(summary.size * 1024))
         const newLiElem = document.getElementById(NAV_ELEM_ID)
-        newLiElem.title = 'Click to load directory sizes'
-        newLiElem.style.cssText = 'cursor: pointer'
-        newLiElem.onclick = loadDirSizes
+        if(viewingDir) {
+          newLiElem.title = 'Click to load directory sizes'
+          newLiElem.onclick = loadDirSizes
+        }
       }
     })
   }
 
-  if (tdElems) return
+  if (!viewingDir || tdElems) return
 
   const tree = await getAPIData(`${repoObj.repo}/contents/${repoObj.currentPath}?ref=${repoObj.ref}`)
   const sizeObj = { '..': '..' }

--- a/src/inject.js
+++ b/src/inject.js
@@ -132,24 +132,20 @@ const checkForRepoPage = async () => {
   const ns = document.querySelector('ul.UnderlineNav-body')
   const navElem = document.getElementById(NAV_ELEM_ID)
   const tdElems = document.querySelector('span.github-repo-size-div')
-  
-  // whether 'add file' button is present
-  const viewingDir = document.querySelector('div.file-navigation.mb-3.d-flex.flex-items-start > div.d-flex > details > summary > span.btn.d-none.d-md-flex.flex-items-center') && true
 
   if (ns && !navElem) {
     getAPIData(repoObj.repo).then(summary => {
       if (summary && summary.size) {
         ns.insertAdjacentHTML('beforeend', getSizeHTML(summary.size * 1024))
         const newLiElem = document.getElementById(NAV_ELEM_ID)
-        if(viewingDir) {
-          newLiElem.title = 'Click to load directory sizes'
-          newLiElem.onclick = loadDirSizes
-        }
+        newLiElem.title = 'Click to load directory sizes'
+        newLiElem.style.cssText = 'cursor: pointer'
+        newLiElem.onclick = loadDirSizes
       }
     })
   }
 
-  if (!viewingDir || tdElems) return
+  if (tdElems) return
 
   const tree = await getAPIData(`${repoObj.repo}/contents/${repoObj.currentPath}?ref=${repoObj.ref}`)
   const sizeObj = { '..': '..' }


### PR DESCRIPTION
The extension tried to update file sizes even when a directory page was not being browsed, which led to error `TypeError: tree.forEach is not a function` on **line 153** (line number before this pull request)
For example, visit page: https://github.com/harshjv/github-repo-size/blob/master/src/inject.js and check extension errors.

This is now fixed by detecting directory view with the presence of the 'Add file' button and updating table only if the button is present.

Also, removed redundant CSS `'cursor: pointer'` for newLiElem.
