### PR TITLE
Update token prompts with GitHub scope info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 extension.zip
-node_modules
+node_modules/
+.idea/

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ To enable viewing size of private repositories;
 1. Install extension from chrome webstore, if you haven't.
 2. Go to https://github.com/settings/tokens to generate your personal access token.
   - Check `repo` scope to enable this extension on private repo.
-3. Click on the Github Repo Size extension (this extension)'s icon aside the address bar.
+3. Click on the GitHub Repo Size extension (this extension)'s icon aside the address bar.
 4. Paste your access token there in the prompt box.
 
 ### Temporarily override the token

--- a/src/background.js
+++ b/src/background.js
@@ -11,7 +11,7 @@ function setGithubToken (key, cb) {
   obj[GITHUB_TOKEN_KEY] = key
 
   storage.set(obj, function () {
-    alert('Your Github token has been set successfully. Reload the Github page to see changes.')
+    alert('Your GitHub token has been set successfully. Reload the GitHub page to see changes.')
 
     cb()
   })
@@ -22,9 +22,9 @@ function handleOldGithubToken (cb) {
     const oldGithubToken = storedData[GITHUB_TOKEN_KEY]
 
     if (oldGithubToken) {
-      if (confirm('You have already set your Github token. Do you want to remove it?')) {
+      if (confirm('You have already set your GitHub token. Do you want to remove it?')) {
         storage.remove(GITHUB_TOKEN_KEY, function () {
-          alert('You have successfully removed Github token. Click extension icon again to set a new token.')
+          alert('You have successfully removed your GitHub token. Click the extension icon again to set a new token.')
 
           cb(null, false)
         })
@@ -49,7 +49,7 @@ function informUserAboutGithubTokenFeature () {
     const userKnows = storedData[TOKEN_FEATURE_INFORMATION_KEY]
 
     if (!userKnows) {
-      if (confirm('GitHub Repository Size now supports private repositories through Github personal access tokens. Do you want to add a token?')) {
+      if (confirm('GitHub Repository Size supports private repositories through a GitHub personal access token (with "repo" scope). Do you want to add it now?')) {
         askGithubToken(() => {
           userNowKnowsAboutGithubTokenFeature(() => {})
         })
@@ -63,7 +63,7 @@ function informUserAboutGithubTokenFeature () {
 }
 
 const askGithubToken = (cb) => {
-  const githubToken = prompt('Please enter your Github token')
+  const githubToken = prompt('Please enter your GitHub token (requires "repo" scope)')
 
   if (githubToken === null) return
 


### PR DESCRIPTION
Include required "repo" scope in GitHub token prompts. Also fix a few minor capitalization typos: `Github` -> `GitHub`.

Closes #51